### PR TITLE
Explicit esprima@4.0.0 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "json-schema-ref-parser": "^3.1.2",
     "livedoc": "^0.1.63",
     "marked": "^0.3.6",
-    "pluralize": "^3.1.0"
+    "pluralize": "^3.1.0",
+    "esprima": "^3.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "livedoc": "^0.1.63",
     "marked": "^0.3.6",
     "pluralize": "^3.1.0",
-    "esprima": "^3.1.3"
+    "esprima": "^4.0.0"
   }
 }


### PR DESCRIPTION
I added an explicit dependency for esprima@4.0.0 in the package.json. Previously a clean install of pretty-swag was using esprima@4.0.0 via a dependency in js-yaml, itself a dependency of json-schema-ref-parser.

This was causing dependency conflicts with other installed modules that require an older version of esprima that isn't compatible with @4.0.0.